### PR TITLE
Adding Basket and Product repositories to (in-memory) persist records

### DIFF
--- a/src/main/java/com/ecomm/checkout/model/Basket.java
+++ b/src/main/java/com/ecomm/checkout/model/Basket.java
@@ -4,8 +4,13 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * A POJO representing a Basket.
+ */
 public class Basket {
     private Long id;
+    private Long userId;
+    private BasketStatus status;
     private List<Product> products;
     private LocalDate created;
     private LocalDate expiration;
@@ -24,6 +29,22 @@ public class Basket {
         this.id = id;
     }
 
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public BasketStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(BasketStatus status) {
+        this.status = status;
+    }
+
     public List<Product> getProducts() {
         return products;
     }
@@ -40,6 +61,10 @@ public class Basket {
         return expiration;
     }
 
+    /**
+     * Convenient method to add a product to the basket
+     * @param product
+     */
     public void addProduct(Product product) {
         this.products.add(product);
     }

--- a/src/main/java/com/ecomm/checkout/model/BasketStatus.java
+++ b/src/main/java/com/ecomm/checkout/model/BasketStatus.java
@@ -1,0 +1,5 @@
+package com.ecomm.checkout.model;
+
+public enum BasketStatus {
+    DRAFT, CONFIRMED, CANCELLED
+}

--- a/src/main/java/com/ecomm/checkout/model/Product.java
+++ b/src/main/java/com/ecomm/checkout/model/Product.java
@@ -2,10 +2,22 @@ package com.ecomm.checkout.model;
 
 import java.math.BigDecimal;
 
+/**
+ * A POJO modeling the product entity.
+ */
 public class Product {
+    private Long id;
     private ProductType productType;
     private BigDecimal price;
     private String productName;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
 
     public ProductType getProductType() {
         return productType;

--- a/src/main/java/com/ecomm/checkout/repository/BasketRepository.java
+++ b/src/main/java/com/ecomm/checkout/repository/BasketRepository.java
@@ -1,0 +1,40 @@
+package com.ecomm.checkout.repository;
+
+import com.ecomm.checkout.model.Basket;
+
+/**
+ * Interface defining database operations that can be done on baskets. On a later stage of development this
+ * interface will extend Spring Data CrudRepository interface, which uses Spring Data JPA to create repository
+ * implementations automatically, at runtime, from a repository interface.
+ *
+ * For now, we will include the same methods included in CrudRepository so later we can swap Repository
+ * implementations to use the auto-implementation feature of Spring Data.
+ *
+ * See https://spring.io/guides/gs/accessing-data-jpa/ for more info.
+ */
+public interface BasketRepository {
+    /**
+     * Saves a basket to DB. Returns the saved basket. If the basket already exists, this method updates it. If it
+     * does not, it auto generates an id and inserts a new record.
+     *
+     * @param basket to create/update
+     * @return the saved basket
+     */
+    Basket save(Basket basket);
+
+    /**
+     * Finds a basket in DB for the specified ID.
+     *
+     * @param id for the basket to find
+     * @return the basket for the specified id, or null if it does not exist
+     */
+    Basket findById(Long id);
+
+    /**
+     * Finds a basket in DB owned by the specified User
+     *
+     * @param userId id of the user owning this basket
+     * @return a basket belonging to this user
+     */
+    Basket findByUserId(Long userId);
+}

--- a/src/main/java/com/ecomm/checkout/repository/BasketRepositoryImpl.java
+++ b/src/main/java/com/ecomm/checkout/repository/BasketRepositoryImpl.java
@@ -1,0 +1,63 @@
+package com.ecomm.checkout.repository;
+
+import com.ecomm.checkout.model.Basket;
+import com.ecomm.checkout.model.BasketStatus;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * In memory data repository to store baskets. Baskets are stored in maps where keys are basket ids, values are the
+ * basket objects.
+ *
+ * This class will be replaced once a real DB is implemented, which is quite simple using Spring Data.
+ */
+@Component
+public class BasketRepositoryImpl implements BasketRepository {
+    private Map<Long, Basket> baskets = new HashMap<>();
+    private Long nextId = 1L;
+
+    /**
+     * If the basket has no id, auto generate one and save the new basket. If it has an id, override what the map has
+     * on that position.
+     * @param basket
+     * @return
+     */
+    public Basket save(Basket basket) {
+        if(basket.getId() == null) {
+            basket.setId(nextId);
+            nextId++;
+        }
+
+        baskets.put(basket.getId(), basket);
+        return basket;
+    }
+
+    /**
+     * Returns a basket with the specified userId, or null if no basket with that id exists.
+     * @param id
+     * @return
+     */
+    public Basket findById(Long id) {
+        return baskets.get(id);
+    }
+
+    /**
+     * Method to find draft basket by its owner id. Implementation is awful but enough for the test. On a real DB
+     * queries would be better
+     * @param userId
+     * @return
+     */
+    public Basket findByUserId(Long userId) {
+        Basket result = null;
+        for(Basket basket : baskets.values()) {
+            if(basket.getUserId() == userId && BasketStatus.DRAFT == basket.getStatus()) {
+                result = basket;
+                break;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/ecomm/checkout/repository/ProductRepository.java
+++ b/src/main/java/com/ecomm/checkout/repository/ProductRepository.java
@@ -1,0 +1,31 @@
+package com.ecomm.checkout.repository;
+
+import com.ecomm.checkout.model.Product;
+
+/**
+ * Interface defining database operations that can be done on products. On a later stage of development this
+ * interface will extend Spring Data CrudRepository interface, which uses Spring Data JPA to create repository
+ * implementations automatically, at runtime, from a repository interface.
+ *
+ * For now, we will include the same methods included in CrudRepository so later we can swap Repository
+ * implementations to use the auto-implementation feature of Spring Data.
+ *
+ * See https://spring.io/guides/gs/accessing-data-jpa/ for more info.
+ */
+public interface ProductRepository {
+    /**
+     * Saves a product to DB. Returns the saved product. If the product already exists, this method updates it. If it
+     * does not, it auto generates an id and inserts a new record.
+     *
+     * @param product to create/update
+     * @return the saved product
+     */
+    Product save(Product product);
+
+    /**
+     * Finds a product by ID in DB.
+     * @param id
+     * @return
+     */
+    Product findById(Long id);
+}

--- a/src/main/java/com/ecomm/checkout/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/ecomm/checkout/repository/ProductRepositoryImpl.java
@@ -1,0 +1,70 @@
+package com.ecomm.checkout.repository;
+
+import com.ecomm.checkout.model.Product;
+import com.ecomm.checkout.model.ProductType;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * In memory data repository initialized with available products. Contains a few methods to add and fetch products to
+ * data structures. Products are stored in a map where keys are product ids, and values are the product objects.
+ *
+ * This class will be replaced once a real DB is implemented, which is quite simple using Spring Data.
+ */
+@Repository
+public class ProductRepositoryImpl implements ProductRepository {
+    private Map<Long, Product> products = new HashMap<>();
+    private Long nextId = 1L;
+
+    /**
+     * Constructor for the Database object. On a real DB this should be placed on an initialization script.
+     */
+    public ProductRepositoryImpl() {
+        Product product = new Product();
+        product.setPrice(BigDecimal.valueOf(5));
+        product.setProductName("Lana Pen");
+        product.setProductType(ProductType.PEN);
+        save(product);
+
+        product = new Product();
+        product.setPrice(BigDecimal.valueOf(20));
+        product.setProductName("Lana T-Shirt");
+        product.setProductType(ProductType.TSHIRT);
+        save(product);
+
+        product = new Product();
+        product.setPrice(BigDecimal.valueOf(7.5));
+        product.setProductName("Lana Coffee Mug");
+        product.setProductType(ProductType.MUG);
+        save(product);
+    }
+
+    /**
+     * Saves or update a product in the products map.
+     *
+     * @param product product to save. If product does not exist in map already, auto generates an ID.
+     * @return the new/updated product.
+     */
+    public Product save(Product product) {
+        if(product.getId() == null) {
+            product.setId(nextId);
+            nextId++;
+        }
+
+        products.put(product.getId(), product);
+        return product;
+    }
+
+    /**
+     * Returns the product with the specified ID in DB if it exists, or null if it does not.
+     *
+     * @param id of the product to fetch
+     * @return the product for the specified ID, or null if no product with that id exists.
+     */
+    public Product findById(Long id) {
+        return products.get(id);
+    }
+}

--- a/src/test/java/com/ecomm/checkout/repository/BasketRepositoryTest.java
+++ b/src/test/java/com/ecomm/checkout/repository/BasketRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.ecomm.checkout.repository;
+
+import com.ecomm.checkout.model.Basket;
+import com.ecomm.checkout.model.BasketStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class BasketRepositoryTest {
+    @Autowired
+    private BasketRepository basketRepository;
+
+    @Test
+    public void testInsertNewBasket() {
+        Basket basket = new Basket();
+        Assertions.assertNull(basket.getId());
+        basket = basketRepository.save(basket);
+        Assertions.assertNotNull(basket.getId());
+
+        Basket fetchedBasket = basketRepository.findById(basket.getId());
+        Assertions.assertNotNull(fetchedBasket);
+    }
+
+    @Test
+    public void testUpdateBasket() {
+        Basket basket = new Basket();
+        basket.setStatus(BasketStatus.DRAFT);
+        basket = basketRepository.save(basket);
+
+        Basket fetchedBasket = basketRepository.findById(basket.getId());
+        fetchedBasket.setStatus(BasketStatus.CANCELLED);
+        basketRepository.save(fetchedBasket);
+
+        Basket updatedBasket = basketRepository.findById(basket.getId());
+        Assertions.assertEquals(BasketStatus.CANCELLED, updatedBasket.getStatus());
+    }
+
+    @Test
+    public void testFindBasketByUserIdFindsDraftBasket() {
+        Basket basket = new Basket();
+        basket.setStatus(BasketStatus.DRAFT);
+        basket.setUserId(3L);
+        basketRepository.save(basket);
+
+        Basket result = basketRepository.findByUserId(3L);
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(3L, basket.getUserId());
+    }
+
+    @Test
+    public void testFindBasketByUserIdBasketCancelledNoResults() {
+        Basket basket = new Basket();
+        basket.setStatus(BasketStatus.CANCELLED);
+        basket.setUserId(5L);
+        basket = basketRepository.save(basket);
+
+        Basket savedBasket = basketRepository.findById(basket.getId());
+        Assertions.assertNotNull(savedBasket);
+
+        Basket result = basketRepository.findByUserId(5L);
+        Assertions.assertNull(result);
+    }
+}

--- a/src/test/java/com/ecomm/checkout/repository/ProductRepositoryTest.java
+++ b/src/test/java/com/ecomm/checkout/repository/ProductRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.ecomm.checkout.repository;
+
+import com.ecomm.checkout.model.Product;
+import com.ecomm.checkout.model.ProductType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class ProductRepositoryTest {
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Test
+    public void testInsertNewProduct() {
+        Product product = new Product();
+        Assertions.assertNull(product.getId());
+        product = productRepository.save(product);
+        Assertions.assertNotNull(product.getId());
+
+        Product fetchedProduct = productRepository.findById(product.getId());
+        Assertions.assertNotNull(fetchedProduct);
+    }
+
+    @Test
+    public void testUpdateProduct() {
+        Product product = new Product();
+        product.setProductName("Some product");
+        product = productRepository.save(product);
+
+        Product fetchedProduct = productRepository.findById(product.getId());
+        fetchedProduct.setProductName("Updated product name");
+        productRepository.save(fetchedProduct);
+
+        Product updatedProduct = productRepository.findById(product.getId());
+        Assertions.assertEquals("Updated product name", updatedProduct.getProductName());
+    }
+
+    @Test
+    public void testFindExistingProducts() {
+        Product pen = productRepository.findById(1L);
+        Assertions.assertEquals(ProductType.PEN, pen.getProductType());
+
+        Product tshirt = productRepository.findById(2L);
+        Assertions.assertEquals(ProductType.TSHIRT, tshirt.getProductType());
+
+        Product mug = productRepository.findById(3L);
+        Assertions.assertEquals(ProductType.MUG, mug.getProductType());
+    }
+}


### PR DESCRIPTION
Including Basket and Product repositories. Implemented using interfaces to hide implementation details. Current implementation is in-memory using a simple Map. Later implementations can be swapped by a real DB implementation. If the contract interface is honored changes would be isolated to the RepositoryImpl classes only, leaving business classes unchanged.

A possible path forward to introducing real DB management would be to use SpringData JPA. To make this change we need make Repository interfaces extend from the CrudRepository interface, which automatically provides repository implementations and the same methods included on this PR. Summary of changes would be to:

* Make Repository interfaces extend from CrudRepository
* Remove save methods from both Repositories, since they are already included in CrudRepository.
* Remove RepositoryImpl classes.
* Include initialization scripts to replace what is currently done on ProductRepositoryImpl constructor.

See https://spring.io/guides/gs/accessing-data-jpa/ for more details

As part of this PR, added some more documentation and the BasketStatus enum to track basket status